### PR TITLE
Add 24-hour local time and editable stamps

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,7 +26,11 @@
       on: $("#btn-on"),
       reset: $("#btn-reset"),
       copy: $("#btn-copy"),
-      install: $("#btn-install")
+      install: $("#btn-install"),
+      editOff: $("#edit-off"),
+      editOut: $("#edit-out"),
+      editIn: $("#edit-in"),
+      editOn: $("#edit-on"),
     },
     installUI: $("#install-ui")
   };
@@ -52,7 +56,8 @@
   function toLocalString(d) {
     return new Date(d).toLocaleString(undefined, {
       year: "numeric", month: "2-digit", day: "2-digit",
-      hour: "2-digit", minute: "2-digit", second: "2-digit"
+      hour: "2-digit", minute: "2-digit", second: "2-digit",
+      hour12: false
     });
   }
   function toUTCString(d) {
@@ -141,6 +146,24 @@
     render();
   }
 
+  function edit(which) {
+    const current = times[which]
+      ? new Date(times[which]).toISOString().slice(0,19).replace("T", " ")
+      : "";
+    const input = prompt(`Enter local time for ${which.toUpperCase()} (YYYY-MM-DD HH:MM:SS)`,
+      current);
+    if (!input) return;
+    const isoLocal = input.trim().replace(" ", "T");
+    const dt = new Date(isoLocal);
+    if (isNaN(dt)) {
+      alert("Invalid time format");
+      return;
+    }
+    times[which] = dt.toISOString();
+    saveTimes();
+    render();
+  }
+
   function resetAll() {
     if (!confirm("Clear all times?")) return;
     times = { off:null, out:null, in:null, on:null };
@@ -188,6 +211,10 @@
   els.btns.out.addEventListener("click", () => stamp("out"));
   els.btns.in.addEventListener("click", () => stamp("in"));
   els.btns.on.addEventListener("click", () => stamp("on"));
+  if (els.btns.editOff) els.btns.editOff.addEventListener("click", () => edit("off"));
+  if (els.btns.editOut) els.btns.editOut.addEventListener("click", () => edit("out"));
+  if (els.btns.editIn) els.btns.editIn.addEventListener("click", () => edit("in"));
+  if (els.btns.editOn) els.btns.editOn.addEventListener("click", () => edit("on"));
   els.btns.reset.addEventListener("click", resetAll);
   els.btns.copy.addEventListener("click", copyAll);
 

--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
           <div id="off-utc" class="mono small muted">—</div>
         </div>
         <button class="btn primary" id="btn-off">Stamp OFF</button>
+        <button class="btn muted" id="edit-off">Edit</button>
       </div>
       <div class="row">
         <div class="label">OUT</div>
@@ -71,6 +72,7 @@
           <div id="out-utc" class="mono small muted">—</div>
         </div>
         <button class="btn primary" id="btn-out">Stamp OUT</button>
+        <button class="btn muted" id="edit-out">Edit</button>
       </div>
       <div class="row">
         <div class="label">IN</div>
@@ -79,6 +81,7 @@
           <div id="in-utc" class="mono small muted">—</div>
         </div>
         <button class="btn primary" id="btn-in">Stamp IN</button>
+        <button class="btn muted" id="edit-in">Edit</button>
       </div>
       <div class="row">
         <div class="label">ON</div>
@@ -87,6 +90,7 @@
           <div id="on-utc" class="mono small muted">—</div>
         </div>
         <button class="btn primary" id="btn-on">Stamp ON</button>
+        <button class="btn muted" id="edit-on">Edit</button>
       </div>
       <div class="spacer"></div>
       <div class="row">


### PR DESCRIPTION
## Summary
- show local timestamps in 24-hour format
- allow manual editing of OFF/OUT/IN/ON stamps

## Testing
- `npm test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f9dab2b08326beeab806c197d038