### PR TITLE
Update header and logo

### DIFF
--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="32" fill="#0f3460"/>
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="central" font-family="Arial, sans-serif" font-weight="700" font-size="96" fill="#e9eef7">FT</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Flight Times Logger (OFF/OUT/IN/ON)</title>
+    <title>Flight Ops Logger</title>
   <meta name="description" content="PWA to log OFF/OUT/IN/ON timestamps with local & UTC times and compute BLOCK & AIR totals.">
   <link rel="manifest" href="manifest.webmanifest">
   <link rel="icon" href="assets/icon-192.png" sizes="192x192">
@@ -16,7 +16,7 @@
     * { box-sizing: border-box; }
     html, body { margin:0; padding:0; background:var(--bg); color:var(--ink); font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
     header { padding: 16px; display:flex; align-items:center; gap:12px; background:rgba(255,255,255,0.03); border-bottom: 1px solid rgba(255,255,255,0.08); position:sticky; top:0; backdrop-filter:saturate(120%) blur(6px); }
-    header img { width:40px; height:40px; border-radius:8px; }
+      header img { width:48px; height:48px; border-radius:8px; }
     header h1 { font-size: 18px; margin:0; }
     main { padding: 20px; max-width: 900px; margin: 0 auto; }
     .grid { display:grid; grid-template-columns: 1fr; gap: 16px; }
@@ -68,13 +68,13 @@
   </style>
 </head>
 <body>
-  <header>
-    <img src="assets/icon-192.png" alt="app icon">
-    <div>
-      <h1>Flight Times Logger</h1>
-      <div class="small muted">OFF / OUT / IN / ON • local &amp; UTC • offline ready</div>
-    </div>
-  </header>
+    <header>
+      <img src="assets/logo.svg" alt="Flight Ops Logger logo">
+      <div>
+        <h1>Flight Ops Logger</h1>
+        <div class="small muted">OFF / OUT / IN / ON • Hobbs • Tach • Fuel • local &amp; UTC • offline ready</div>
+      </div>
+    </header>
 
   <main>
     <section class="card">

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,20 +1,25 @@
 {
-  "name": "Flight Times Logger",
-  "short_name": "Times Logger",
+  "name": "Flight Ops Logger",
+  "short_name": "Ops Logger",
   "start_url": ".",
   "display": "standalone",
   "background_color": "#0a285a",
   "theme_color": "#0a285a",
   "icons": [
-    {
-      "src": "assets/icon-192.png",
-      "sizes": "192x192",
-      "type": "image/png"
-    },
-    {
-      "src": "assets/icon-512.png",
-      "sizes": "512x512",
-      "type": "image/png"
-    }
-  ]
+      {
+        "src": "assets/icon-192.png",
+        "sizes": "192x192",
+        "type": "image/png"
+      },
+      {
+        "src": "assets/icon-512.png",
+        "sizes": "512x512",
+        "type": "image/png"
+      },
+      {
+        "src": "assets/logo.svg",
+        "sizes": "any",
+        "type": "image/svg+xml"
+      }
+    ]
 }


### PR DESCRIPTION
## Summary
- Rename app to "Flight Ops Logger" and expand header tagline to cover Hobbs, Tach, and Fuel tracking
- Enlarge header logo and add new SVG icon for improved readability
- Include updated app name and SVG icon in web manifest

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa19f1fd3c832695db54332533159f