### PR TITLE
Allow editing fuel in gallons and pounds

### DIFF
--- a/app.js
+++ b/app.js
@@ -258,11 +258,25 @@
     render();
   }
 
-  function updateFuel(){
-    const s = parseFloat(els.fuelStart.value);
-    const e = parseFloat(els.fuelEnd.value);
-    extra.fuelStart = isNaN(s) ? null : s;
-    extra.fuelEnd = isNaN(e) ? null : e;
+  function updateFuel(which, unit){
+    const factor = els.fuelType.value === "JetA" ? 6.7 : 6.0;
+    if(which === "start"){
+      if(unit === "usg"){
+        const s = parseFloat(els.fuelStart.value);
+        extra.fuelStart = isNaN(s) ? null : s;
+      } else if(unit === "lbs"){
+        const sL = parseFloat(els.fuelStartLbs.value);
+        extra.fuelStart = isNaN(sL) ? null : sL / factor;
+      }
+    } else if(which === "end"){
+      if(unit === "usg"){
+        const e = parseFloat(els.fuelEnd.value);
+        extra.fuelEnd = isNaN(e) ? null : e;
+      } else if(unit === "lbs"){
+        const eL = parseFloat(els.fuelEndLbs.value);
+        extra.fuelEnd = isNaN(eL) ? null : eL / factor;
+      }
+    }
     extra.fuelType = els.fuelType.value;
     saveExtra();
     render();
@@ -338,13 +352,11 @@
     els.tachUsed.textContent = tachDisp;
 
     els.fuelType.value = extra.fuelType || "100LL";
-    els.fuelStart.value = extra.fuelStart ?? "";
-    els.fuelEnd.value = extra.fuelEnd ?? "";
     const factor = extra.fuelType === "JetA" ? 6.7 : 6.0;
-    const fsLbsVal = extra.fuelStart != null ? (extra.fuelStart * factor).toFixed(1) : null;
-    els.fuelStartLbs.textContent = fsLbsVal != null ? `${fsLbsVal} lbs` : "— lbs";
-    const feLbsVal = extra.fuelEnd != null ? (extra.fuelEnd * factor).toFixed(1) : null;
-    els.fuelEndLbs.textContent = feLbsVal != null ? `${feLbsVal} lbs` : "— lbs";
+    els.fuelStart.value = extra.fuelStart != null ? extra.fuelStart.toFixed(1) : "";
+    els.fuelStartLbs.value = extra.fuelStart != null ? (extra.fuelStart * factor).toFixed(1) : "";
+    els.fuelEnd.value = extra.fuelEnd != null ? extra.fuelEnd.toFixed(1) : "";
+    els.fuelEndLbs.value = extra.fuelEnd != null ? (extra.fuelEnd * factor).toFixed(1) : "";
     const fuelUsedVal =
       extra.fuelStart != null && extra.fuelEnd != null && extra.fuelStart >= extra.fuelEnd
         ? extra.fuelStart - extra.fuelEnd
@@ -511,9 +523,11 @@
     els[`${w}End`].addEventListener("change", () => updateMeter(w));
     els.btns[`${w}Reset`].addEventListener("click", () => resetMeter(w));
   });
-  els.fuelType.addEventListener("change", updateFuel);
-  els.fuelStart.addEventListener("change", updateFuel);
-  els.fuelEnd.addEventListener("change", updateFuel);
+  els.fuelType.addEventListener("change", () => updateFuel());
+  els.fuelStart.addEventListener("change", () => updateFuel("start","usg"));
+  els.fuelStartLbs.addEventListener("change", () => updateFuel("start","lbs"));
+  els.fuelEnd.addEventListener("change", () => updateFuel("end","usg"));
+  els.fuelEndLbs.addEventListener("change", () => updateFuel("end","lbs"));
   els.btns.fuelReset.addEventListener("click", resetFuel);
   els.tripNumber.addEventListener("change", updateTripLeg);
   els.legNumber.addEventListener("change", updateTripLeg);

--- a/index.html
+++ b/index.html
@@ -199,12 +199,12 @@
         <div class="row">
           <div class="label">Start:</div>
           <input id="fuel-start" class="mono local-input" placeholder="USG" inputmode="decimal" pattern="[0-9.]*">
-          <span id="fuel-start-lbs" class="mono small muted">— lbs</span>
+          <input id="fuel-start-lbs" class="mono local-input" placeholder="lbs" inputmode="decimal" pattern="[0-9.]*">
         </div>
         <div class="row">
           <div class="label">End:</div>
           <input id="fuel-end" class="mono local-input" placeholder="USG" inputmode="decimal" pattern="[0-9.]*">
-          <span id="fuel-end-lbs" class="mono small muted">— lbs</span>
+          <input id="fuel-end-lbs" class="mono local-input" placeholder="lbs" inputmode="decimal" pattern="[0-9.]*">
         </div>
         <div class="row">
           <button class="btn warn" id="btn-fuel-reset">Reset</button>


### PR DESCRIPTION
## Summary
- Add inputs for fuel start/end in pounds alongside gallons
- Convert between gallons and pounds based on fuel type
- Synchronize new fields and totals in UI

## Testing
- `node --check app.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa497f26ac8326b730dfbef64a50ce