### PR TITLE
Swap AIR and BLOCK calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flight Times Logger (PWA)
 
-Log **OFF/OUT/IN/ON** timestamps with both **local** and **UTC** display, and get **AIR (OFF→ON)** and **BLOCK (OUT→IN)** totals in:
+Log **OFF/OUT/IN/ON** timestamps with both **local** and **UTC** display, and get **AIR (OUT→IN)** and **BLOCK (OFF→ON)** totals in:
 - **HH:MM**
 - **Decimal hours** (e.g., 1.75)
 - **Tenths of hours** (e.g., 1.8)

--- a/app.js
+++ b/app.js
@@ -317,8 +317,8 @@
     });
 
     // Totals
-    const airMins = minutesBetween(times.off, times.on);
-    const blockMins = minutesBetween(times.out, times.in);
+    const airMins = minutesBetween(times.out, times.in);
+    const blockMins = minutesBetween(times.off, times.on);
 
     els.airHHMM.textContent = fmtHHMM(airMins);
     const aD = fmtDecimals(airMins);
@@ -450,14 +450,14 @@
     push("IN", times.in);
     push("ON", times.on);
 
-    const airMins = minutesBetween(times.off, times.on);
-    const blockMins = minutesBetween(times.out, times.in);
+    const airMins = minutesBetween(times.out, times.in);
+    const blockMins = minutesBetween(times.off, times.on);
     const aD = fmtDecimals(airMins);
     const bD = fmtDecimals(blockMins);
 
     lines.push("");
-    lines.push(`AIR (OFF→ON): ${fmtHHMM(airMins)} | Decimal ${aD.dec} | Tenths ${aD.tenths}`);
-    lines.push(`BLOCK (OUT→IN): ${fmtHHMM(blockMins)} | Decimal ${bD.dec} | Tenths ${bD.tenths}`);
+    lines.push(`AIR (OUT→IN): ${fmtHHMM(airMins)} | Decimal ${aD.dec} | Tenths ${aD.tenths}`);
+    lines.push(`BLOCK (OFF→ON): ${fmtHHMM(blockMins)} | Decimal ${bD.dec} | Tenths ${bD.tenths}`);
 
     const hobbsUsed = extra.hobbsStart != null && extra.hobbsEnd != null ? (extra.hobbsEnd - extra.hobbsStart).toFixed(1) : "—";
     const tachUsed = extra.tachStart != null && extra.tachEnd != null ? (extra.tachEnd - extra.tachStart).toFixed(1) : "—";

--- a/index.html
+++ b/index.html
@@ -215,12 +215,12 @@
       <div class="section-title">Totals</div>
       <div class="grid">
         <div>
-          <div class="badge">AIR (OFF → ON)</div>
+          <div class="badge">AIR (OUT → IN)</div>
           <div class="kpi mono" id="air-hhmm">—</div>
           <div class="mono small muted" id="air-decimals">—</div>
         </div>
         <div>
-          <div class="badge">BLOCK (OUT → IN)</div>
+          <div class="badge">BLOCK (OFF → ON)</div>
           <div class="kpi mono" id="block-hhmm">—</div>
           <div class="mono small muted" id="block-decimals">—</div>
         </div>


### PR DESCRIPTION
## Summary
- swap AIR and BLOCK calculations: air now uses OUT→IN while block uses OFF→ON
- update totals section labels to match new definitions
- refresh README to describe updated AIR and BLOCK pairing

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac80823d3483268aa173c0b37a1421