### PR TITLE
Rename app to Flight Timer

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Flight Ops Logger</title>
+    <title>Flight Timer</title>
   <meta name="description" content="PWA to log OFF/OUT/IN/ON timestamps with local & UTC times and compute BLOCK & AIR totals.">
     <link rel="manifest" href="manifest.webmanifest">
     <link rel="icon" href="assets/logo.svg" type="image/svg+xml">
@@ -92,9 +92,9 @@
 </head>
 <body>
     <header>
-      <img src="assets/logo.svg" alt="Flight Ops Logger logo">
+      <img src="assets/logo.svg" alt="Flight Timer logo">
       <div>
-        <h1>Flight Ops Logger</h1>
+        <h1>Flight Timer</h1>
         <div class="small muted">OFF / OUT / IN / ON • Hobbs • Tach • Fuel • local &amp; UTC • offline ready</div>
       </div>
     </header>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "Flight Ops Logger",
-  "short_name": "Ops Logger",
+  "name": "Flight Timer",
+  "short_name": "Flight Timer",
   "start_url": ".",
   "display": "standalone",
   "background_color": "#0a285a",


### PR DESCRIPTION
## Summary
- rename PWA name and short name to Flight Timer
- update HTML title, heading, and logo alt text to use Flight Timer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac87ebdb348326a4029958a44b0dbd