### PR TITLE
Fix navigation skipping time fields

### DIFF
--- a/app.js
+++ b/app.js
@@ -67,7 +67,6 @@
     installCard: $("#install-card")
   };
 
-  const editing = { off:false, out:false, in:false, on:false };
 
   const emptyTimes = { off:null, out:null, in:null, on:null };
   const emptyExtra = {
@@ -216,7 +215,6 @@
     }
     times[which] = base.toISOString();
     saveTimes();
-    editing[which] = false;
     render();
   }
 
@@ -224,21 +222,8 @@
     if(!times[which]) return;
     if(!confirm(`Reset ${which.toUpperCase()}?`)) return;
     times[which] = null;
-    editing[which] = false;
     saveTimes();
     render();
-  }
-
-  function startEdit(which){
-    if (editing[which]) return;
-    editing[which] = true;
-    const input = els[`${which}Local`];
-    input.readOnly = false;
-    const len = input.value.length;
-    setTimeout(() => {
-      input.focus();
-      input.setSelectionRange(len, len);
-    }, 0);
   }
 
   function updateMeter(which){
@@ -313,7 +298,6 @@
         els.btns[w].disabled = false;
         els.btns[`${w}Reset`].disabled = true;
       }
-      els[`${w}Local`].readOnly = !editing[w];
     });
 
     // Totals
@@ -429,7 +413,6 @@
     if (!confirm("Reset all data?")) return;
     times = { ...emptyTimes };
     extra = { ...emptyExtra };
-    editing.off = editing.out = editing.in = editing.on = false;
     saveTimes();
     saveExtra();
     render();
@@ -508,13 +491,6 @@
     const input = els[`${w}Local`];
     input.addEventListener("input", formatTimeInput);
     input.addEventListener("change", () => updateFromInput(w));
-    input.addEventListener("blur", () => {
-      editing[w] = false;
-      input.readOnly = true;
-    });
-    const activate = () => startEdit(w);
-    input.addEventListener("touchstart", activate);
-    input.addEventListener("mousedown", activate);
     els.btns[`${w}Reset`].addEventListener("click", () => resetOne(w));
   });
 

--- a/index.html
+++ b/index.html
@@ -256,7 +256,7 @@
     <footer>
       <div>Timezone: <select id="tz" class="mono"></select></div>
       <div class="small muted">All data stored locally on this device.</div>
-      <div class="small muted">Version 1.0</div>
+      <div class="small muted">Version 1.1</div>
     </footer>
   </main>
 

--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
       <div class="row">
         <button class="label" id="btn-off" type="button">OFF:</button>
         <div class="time">
-          <input id="off-local" class="mono local-input" placeholder="HH:MM:SS" inputmode="numeric" pattern="[0-9:]*" maxlength="8" readonly>
+          <input id="off-local" class="mono local-input" placeholder="HH:MM:SS" inputmode="numeric" pattern="[0-9:]*" maxlength="8">
           <span id="off-utc" class="mono small muted utc">—</span>
         </div>
         <button class="btn warn" id="btn-off-reset">Reset</button>
@@ -133,7 +133,7 @@
       <div class="row">
         <button class="label" id="btn-out" type="button">OUT:</button>
         <div class="time">
-          <input id="out-local" class="mono local-input" placeholder="HH:MM:SS" inputmode="numeric" pattern="[0-9:]*" maxlength="8" readonly>
+          <input id="out-local" class="mono local-input" placeholder="HH:MM:SS" inputmode="numeric" pattern="[0-9:]*" maxlength="8">
           <span id="out-utc" class="mono small muted utc">—</span>
         </div>
         <button class="btn warn" id="btn-out-reset">Reset</button>
@@ -141,7 +141,7 @@
       <div class="row">
         <button class="label" id="btn-in" type="button">IN:</button>
         <div class="time">
-          <input id="in-local" class="mono local-input" placeholder="HH:MM:SS" inputmode="numeric" pattern="[0-9:]*" maxlength="8" readonly>
+          <input id="in-local" class="mono local-input" placeholder="HH:MM:SS" inputmode="numeric" pattern="[0-9:]*" maxlength="8">
           <span id="in-utc" class="mono small muted utc">—</span>
         </div>
         <button class="btn warn" id="btn-in-reset">Reset</button>
@@ -149,7 +149,7 @@
       <div class="row">
         <button class="label" id="btn-on" type="button">ON:</button>
         <div class="time">
-          <input id="on-local" class="mono local-input" placeholder="HH:MM:SS" inputmode="numeric" pattern="[0-9:]*" maxlength="8" readonly>
+          <input id="on-local" class="mono local-input" placeholder="HH:MM:SS" inputmode="numeric" pattern="[0-9:]*" maxlength="8">
           <span id="on-utc" class="mono small muted utc">—</span>
         </div>
         <button class="btn warn" id="btn-on-reset">Reset</button>


### PR DESCRIPTION
## Summary
- Allow OFF/OUT/IN/ON inputs to be focusable and editable
- Simplify event listeners for time fields

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac88c23c508326ad1c313ba6d8c7f8