### PR TITLE
Add tap-to-toggle decimal display for totals

### DIFF
--- a/app.js
+++ b/app.js
@@ -157,6 +157,21 @@
     return Math.round(ms / 60000); // minutes
   }
 
+  function secondsBetween(a, b) {
+    if (!a || !b) return null;
+    const ms = new Date(b) - new Date(a);
+    if (ms < 0) return null;
+    return Math.round(ms / 1000); // seconds
+  }
+
+  function fmtHHMMSS(secs) {
+    if (secs == null) return "—";
+    const h = Math.floor(secs / 3600);
+    const m = Math.floor((secs % 3600) / 60);
+    const s = secs % 60;
+    return `${String(h).padStart(2,"0")}:${String(m).padStart(2,"0")}:${String(s).padStart(2,"0")}`;
+  }
+
   function fmtHHMM(mins) {
     if (mins == null) return "—";
     const h = Math.floor(mins / 60);
@@ -301,14 +316,24 @@
     });
 
     // Totals
-    const airMins = minutesBetween(times.out, times.in);
-    const blockMins = minutesBetween(times.off, times.on);
+    const airSecs = secondsBetween(times.out, times.in);
+    const blockSecs = secondsBetween(times.off, times.on);
+    const airMins = airSecs != null ? Math.round(airSecs / 60) : null;
+    const blockMins = blockSecs != null ? Math.round(blockSecs / 60) : null;
 
-    els.airHHMM.textContent = fmtHHMM(airMins);
+    els.airHHMM.dataset.hhmmss = fmtHHMMSS(airSecs);
+    els.airHHMM.dataset.decimal = airSecs != null ? (airSecs / 3600).toFixed(2) : "—";
+    if (!els.airHHMM.dataset.mode) els.airHHMM.dataset.mode = "hhmmss";
+    els.airHHMM.textContent =
+      els.airHHMM.dataset.mode === "decimal" ? els.airHHMM.dataset.decimal : els.airHHMM.dataset.hhmmss;
     const aD = fmtDecimals(airMins);
     els.airDecimals.textContent = `Decimal: ${aD.dec} • Tenths: ${aD.tenths}`;
 
-    els.blockHHMM.textContent = fmtHHMM(blockMins);
+    els.blockHHMM.dataset.hhmmss = fmtHHMMSS(blockSecs);
+    els.blockHHMM.dataset.decimal = blockSecs != null ? (blockSecs / 3600).toFixed(2) : "—";
+    if (!els.blockHHMM.dataset.mode) els.blockHHMM.dataset.mode = "hhmmss";
+    els.blockHHMM.textContent =
+      els.blockHHMM.dataset.mode === "decimal" ? els.blockHHMM.dataset.decimal : els.blockHHMM.dataset.hhmmss;
     const bD = fmtDecimals(blockMins);
     els.blockDecimals.textContent = `Decimal: ${bD.dec} • Tenths: ${bD.tenths}`;
 
@@ -479,6 +504,11 @@
     render();
   }
 
+  function toggleTimeDisplay(el) {
+    el.dataset.mode = el.dataset.mode === "decimal" ? "hhmmss" : "decimal";
+    el.textContent = el.dataset.mode === "decimal" ? el.dataset.decimal : el.dataset.hhmmss;
+  }
+
   // Wire up UI
   els.btns.off.addEventListener("click", () => stamp("off"));
   els.btns.out.addEventListener("click", () => stamp("out"));
@@ -508,6 +538,8 @@
   els.tripNumber.addEventListener("change", updateTripLeg);
   els.legNumber.addEventListener("change", updateTripLeg);
   els.tz.addEventListener("change", handleTZChange);
+  els.airHHMM.addEventListener("click", () => toggleTimeDisplay(els.airHHMM));
+  els.blockHHMM.addEventListener("click", () => toggleTimeDisplay(els.blockHHMM));
 
   // Install prompt handling
   window.addEventListener("beforeinstallprompt", (e) => {

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
     .btn.block { width: 100%; }
     .btn:disabled { background: rgba(255,255,255,0.08); color: var(--muted); cursor:not-allowed; }
     .kpi { font-size: 32px; font-weight: 700; }
+    #air-hhmm, #block-hhmm { cursor: pointer; }
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
     .muted { color: var(--muted); }
       .label {


### PR DESCRIPTION
## Summary
- Allow tapping AIR and BLOCK totals to swap between HH:MM:SS and decimal hours
- Compute full-second durations and store both formatted and decimal versions for toggling
- Mark totals as clickable in the UI

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae6ee99eec83269137678f5c956686