### PR TITLE
feat: auto-update app when online

### DIFF
--- a/app.js
+++ b/app.js
@@ -541,7 +541,18 @@
   // SW registration
   if ("serviceWorker" in navigator) {
     window.addEventListener("load", () => {
-      navigator.serviceWorker.register("./sw.js").catch(console.error);
+      navigator.serviceWorker
+        .register("./sw.js")
+        .then((reg) => {
+          const update = () => reg.update().catch(() => {});
+          update();
+          window.addEventListener("online", update);
+        })
+        .catch(console.error);
+
+      navigator.serviceWorker.addEventListener("controllerchange", () => {
+        window.location.reload();
+      });
     });
   }
 

--- a/index.html
+++ b/index.html
@@ -260,7 +260,7 @@
     <footer>
       <div>Timezone: <select id="tz" class="mono"></select></div>
       <div class="small muted">All data stored locally on this device.</div>
-      <div class="small muted">Version 1.2</div>
+      <div class="small muted">Version 1.21</div>
     </footer>
   </main>
 


### PR DESCRIPTION
## Summary
- check for new service worker versions when the app loads or regains connectivity
- reload the app when a new service worker activates to ensure users get the latest release
- bump displayed app version to 1.21

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0094c16a4832687f4f69f0689ea8d