### PR TITLE
Swap block and air time sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flight Times Logger (PWA)
 
-Log **OFF/OUT/IN/ON** timestamps with both **local** and **UTC** display, and get **AIR (OFF→ON)** and **BLOCK (OUT→IN)** totals in:
+Log **OFF/OUT/IN/ON** timestamps with both **local** and **UTC** display, and get **BLOCK (OUT→IN)** and **AIR (OFF→ON)** totals in:
 - **HH:MM**
 - **Decimal hours** (e.g., 1.75)
 - **Tenths of hours** (e.g., 1.8)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flight Times Logger (PWA)
 
-Log **OFF/OUT/IN/ON** timestamps with both **local** and **UTC** display, and get **AIR (OUT→IN)** and **BLOCK (OFF→ON)** totals in:
+Log **OFF/OUT/IN/ON** timestamps with both **local** and **UTC** display, and get **AIR (OFF→ON)** and **BLOCK (OUT→IN)** totals in:
 - **HH:MM**
 - **Decimal hours** (e.g., 1.75)
 - **Tenths of hours** (e.g., 1.8)

--- a/app.js
+++ b/app.js
@@ -328,8 +328,8 @@
     });
 
     // Totals
-    const airMins = minutesBetween(times.out, times.in);
-    const blockMins = minutesBetween(times.off, times.on);
+    const airMins = minutesBetween(times.off, times.on);
+    const blockMins = minutesBetween(times.out, times.in);
 
     els.airHHMM.textContent = fmtHHMM(airMins);
     const aD = fmtDecimals(airMins);
@@ -461,16 +461,16 @@
     push("IN", times.in);
     push("ON", times.on);
 
-    const airMins = minutesBetween(times.out, times.in);
-    const blockMins = minutesBetween(times.off, times.on);
+    const airMins = minutesBetween(times.off, times.on);
+    const blockMins = minutesBetween(times.out, times.in);
     if (airMins != null || blockMins != null) lines.push("");
     if (airMins != null) {
       const aD = fmtDecimals(airMins);
-      lines.push(`AIR (OUT→IN): ${fmtHHMM(airMins)} | Decimal ${aD.dec} | Tenths ${aD.tenths}`);
+      lines.push(`AIR (OFF→ON): ${fmtHHMM(airMins)} | Decimal ${aD.dec} | Tenths ${aD.tenths}`);
     }
     if (blockMins != null) {
       const bD = fmtDecimals(blockMins);
-      lines.push(`BLOCK (OFF→ON): ${fmtHHMM(blockMins)} | Decimal ${bD.dec} | Tenths ${bD.tenths}`);
+      lines.push(`BLOCK (OUT→IN): ${fmtHHMM(blockMins)} | Decimal ${bD.dec} | Tenths ${bD.tenths}`);
     }
 
     const hobbsUsed = extra.hobbsStart != null && extra.hobbsEnd != null ? (extra.hobbsEnd - extra.hobbsStart).toFixed(1) : null;

--- a/app.js
+++ b/app.js
@@ -328,16 +328,16 @@
     });
 
     // Totals
-    const airMins = minutesBetween(times.off, times.on);
     const blockMins = minutesBetween(times.out, times.in);
-
-    els.airHHMM.textContent = fmtHHMM(airMins);
-    const aD = fmtDecimals(airMins);
-    els.airDecimals.textContent = `Decimal: ${aD.dec} • Tenths: ${aD.tenths}`;
+    const airMins = minutesBetween(times.off, times.on);
 
     els.blockHHMM.textContent = fmtHHMM(blockMins);
     const bD = fmtDecimals(blockMins);
     els.blockDecimals.textContent = `Decimal: ${bD.dec} • Tenths: ${bD.tenths}`;
+
+    els.airHHMM.textContent = fmtHHMM(airMins);
+    const aD = fmtDecimals(airMins);
+    els.airDecimals.textContent = `Decimal: ${aD.dec} • Tenths: ${aD.tenths}`;
 
     // Extras
     els.tripNumber.value = extra.tripNumber ?? "";
@@ -456,21 +456,21 @@
       if (!val) return;
       lines.push(`${label}: Local ${toLocalString(val)} | UTC ${toUTCString(val)}`);
     };
-    push("OFF", times.off);
     push("OUT", times.out);
-    push("IN", times.in);
+    push("OFF", times.off);
     push("ON", times.on);
+    push("IN", times.in);
 
-    const airMins = minutesBetween(times.off, times.on);
     const blockMins = minutesBetween(times.out, times.in);
+    const airMins = minutesBetween(times.off, times.on);
     if (airMins != null || blockMins != null) lines.push("");
-    if (airMins != null) {
-      const aD = fmtDecimals(airMins);
-      lines.push(`AIR (OFF→ON): ${fmtHHMM(airMins)} | Decimal ${aD.dec} | Tenths ${aD.tenths}`);
-    }
     if (blockMins != null) {
       const bD = fmtDecimals(blockMins);
       lines.push(`BLOCK (OUT→IN): ${fmtHHMM(blockMins)} | Decimal ${bD.dec} | Tenths ${bD.tenths}`);
+    }
+    if (airMins != null) {
+      const aD = fmtDecimals(airMins);
+      lines.push(`AIR (OFF→ON): ${fmtHHMM(airMins)} | Decimal ${aD.dec} | Tenths ${aD.tenths}`);
     }
 
     const hobbsUsed = extra.hobbsStart != null && extra.hobbsEnd != null ? (extra.hobbsEnd - extra.hobbsStart).toFixed(1) : null;
@@ -514,10 +514,10 @@
   }
 
   // Wire up UI
-  els.btns.off.addEventListener("click", () => stamp("off"));
   els.btns.out.addEventListener("click", () => stamp("out"));
-  els.btns.in.addEventListener("click", () => stamp("in"));
+  els.btns.off.addEventListener("click", () => stamp("off"));
   els.btns.on.addEventListener("click", () => stamp("on"));
+  els.btns.in.addEventListener("click", () => stamp("in"));
   els.btns.reset.addEventListener("click", resetAll);
   els.btns.copy.addEventListener("click", copyAll);
 

--- a/index.html
+++ b/index.html
@@ -260,7 +260,7 @@
     <footer>
       <div>Timezone: <select id="tz" class="mono"></select></div>
       <div class="small muted">All data stored locally on this device.</div>
-      <div class="small muted">Version 1.32</div>
+      <div class="small muted">Version 1.4</div>
     </footer>
   </main>
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Flight Timer</title>
-  <meta name="description" content="PWA to log OFF/OUT/IN/ON timestamps with local & UTC times and compute BLOCK & AIR totals.">
+  <meta name="description" content="PWA to log OFF/OUT/IN/ON timestamps with local & UTC times and compute BLOCK (OUT→IN) & AIR (OFF→ON) totals.">
     <link rel="manifest" href="manifest.webmanifest">
     <link rel="icon" href="assets/logo.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="assets/logo.svg">
@@ -219,12 +219,12 @@
       <div class="section-title">Totals</div>
       <div class="grid">
         <div>
-          <div class="badge">AIR (OUT → IN)</div>
+          <div class="badge">AIR (OFF → ON)</div>
           <div class="kpi mono" id="air-hhmm">—</div>
           <div class="mono small muted" id="air-decimals">—</div>
         </div>
         <div>
-          <div class="badge">BLOCK (OFF → ON)</div>
+          <div class="badge">BLOCK (OUT → IN)</div>
           <div class="kpi mono" id="block-hhmm">—</div>
           <div class="mono small muted" id="block-decimals">—</div>
         </div>

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
         <li>Tap each label to capture the current local time; UTC appears beside it.</li>
         <li>Touch the time to edit or add a manual input</li>
         <li>Enter Hobbs, Tach, and Fuel readings to track usage.</li>
-        <li>Totals show AIR, BLOCK, and other values.</li>
+        <li>Totals show BLOCK, AIR, and other values.</li>
         <li>Data stays on this device and the app works offline.</li>
       </ul>
     </details>
@@ -123,14 +123,6 @@
       </div>
       <div class="spacer"></div>
       <div class="row">
-        <button class="label" id="btn-off" type="button">OFF:</button>
-        <div class="time">
-          <input id="off-local" class="mono local-input" placeholder="HH:MM:SS" inputmode="numeric" pattern="[0-9:]*" maxlength="8">
-          <span id="off-utc" class="mono small muted utc">—</span>
-        </div>
-        <button class="btn warn" id="btn-off-reset">Reset</button>
-      </div>
-      <div class="row">
         <button class="label" id="btn-out" type="button">OUT:</button>
         <div class="time">
           <input id="out-local" class="mono local-input" placeholder="HH:MM:SS" inputmode="numeric" pattern="[0-9:]*" maxlength="8">
@@ -139,12 +131,12 @@
         <button class="btn warn" id="btn-out-reset">Reset</button>
       </div>
       <div class="row">
-        <button class="label" id="btn-in" type="button">IN:</button>
+        <button class="label" id="btn-off" type="button">OFF:</button>
         <div class="time">
-          <input id="in-local" class="mono local-input" placeholder="HH:MM:SS" inputmode="numeric" pattern="[0-9:]*" maxlength="8">
-          <span id="in-utc" class="mono small muted utc">—</span>
+          <input id="off-local" class="mono local-input" placeholder="HH:MM:SS" inputmode="numeric" pattern="[0-9:]*" maxlength="8">
+          <span id="off-utc" class="mono small muted utc">—</span>
         </div>
-        <button class="btn warn" id="btn-in-reset">Reset</button>
+        <button class="btn warn" id="btn-off-reset">Reset</button>
       </div>
       <div class="row">
         <button class="label" id="btn-on" type="button">ON:</button>
@@ -153,6 +145,14 @@
           <span id="on-utc" class="mono small muted utc">—</span>
         </div>
         <button class="btn warn" id="btn-on-reset">Reset</button>
+      </div>
+      <div class="row">
+        <button class="label" id="btn-in" type="button">IN:</button>
+        <div class="time">
+          <input id="in-local" class="mono local-input" placeholder="HH:MM:SS" inputmode="numeric" pattern="[0-9:]*" maxlength="8">
+          <span id="in-utc" class="mono small muted utc">—</span>
+        </div>
+        <button class="btn warn" id="btn-in-reset">Reset</button>
       </div>
     </section>
       <section class="card">
@@ -219,14 +219,14 @@
       <div class="section-title">Totals</div>
       <div class="grid">
         <div>
-          <div class="badge">AIR (OFF → ON)</div>
-          <div class="kpi mono" id="air-hhmm">—</div>
-          <div class="mono small muted" id="air-decimals">—</div>
-        </div>
-        <div>
           <div class="badge">BLOCK (OUT → IN)</div>
           <div class="kpi mono" id="block-hhmm">—</div>
           <div class="mono small muted" id="block-decimals">—</div>
+        </div>
+        <div>
+          <div class="badge">AIR (OFF → ON)</div>
+          <div class="kpi mono" id="air-hhmm">—</div>
+          <div class="mono small muted" id="air-decimals">—</div>
         </div>
         <div>
           <div class="badge">HOBBS USED</div>


### PR DESCRIPTION
## Summary
- swap air and block calculations to use OFF→ON for air and OUT→IN for block throughout the app
- update copy-to-clipboard text and totals badges to reflect the new mappings
- refresh README and metadata description with the revised definitions

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ce99d9dfdc8326a30612d078047853